### PR TITLE
Releasing 0.0.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build & Test
+
+on:
+  pull_request:
+    branches: [ dev-master ]
+
+jobs:
+  test-color-core:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Cache Gradle
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Making gradlew executable
+        run: chmod +x ./gradlew
+        working-directory: .
+      - name: Building theme-core
+        run: ./gradlew :theme-core:build
+        working-directory: .
+      - name: Building theme-react
+        run: ./gradlew :theme-react:build
+        working-directory: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,26 @@
-# 0.0.2
+# 0.0.1
 ## Availability
 - Published to maven central
 
 ## Build Src
-- Updated to gradle version 6.7
+- Updated to gradle version 6.7.1
 
 ## New Features
-### gradle-plugins
-- Added the `tz.co.asoft.konfig` plugin
-- Added the `tz.co.asoft.application` plugin
+### theme-core-metadata
+- Added `ColorPallet` class
+- Added `Theme<T>` class
+
+### theme-core-js
+- Added `TextStyle` class for any web framework
+- Added `Typograpgy` class for any web framework
+- Added `operator fun Color.invoke()` to make it easy convert to CSS colors
+
+### theme-react
+- Added `TextStyle`
+- Added `ReactTheme` type alias of `Theme<Typography>`
+- Added `ThemeContext`
+- Added `fun RBuilder.ThemeProvider(...)`
+- Added `fun RBuilder.ThemeConsumer(...)`
 
 ### library
 - Added the `konfig()` method, on all supported platforms

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# aSoft Reakt
+# aSoft Theme
 ![badge][badge-maven] ![badge][badge-mpp] ![badge][badge-android] ![badge][badge-js] ![badge][badge-jvm]
 
 A gradle tool that helps inject values during build configurations and that can be retrieve at runtime.

--- a/README.md
+++ b/README.md
@@ -1,261 +1,126 @@
 # aSoft Theme
 ![badge][badge-maven] ![badge][badge-mpp] ![badge][badge-android] ![badge][badge-js] ![badge][badge-jvm]
 
-A gradle tool that helps inject values during build configurations and that can be retrieve at runtime.
-
-In other words, it brings buildTypes with structured basic data to kotlin-multiplatform applications
+A kotlin multiplatform theme engine
 
 ## Introduction
-Ever wanted to have different build types in your multiplatform application? You feel like most of the time
-your configurations during development time won't match those during deployment? `konfig` has you covered
+Ever wanted to define your theme once and port it to different platforms? This is the way
 
 ## Samples
-In your build logic (gradle), you can inject values like this
+Define your ColorPalette in multiplatform code
 ```kotlin
-konfig {
-    debug(
-        "change" to 1,
-        "link" to "http://debug.com"
-    )
-
-    staging(
-        "link" to "https://staging.com"
-    )
-
-    release(
-        "link" to "https://release.com"
-    )
-}
+val AquaGreenPallet = ColorPalette(
+    primary = Color(0xFF0E9B8A),
+    primaryVariant = Color(0xFF006C5D),
+    onPrimary = Color(0xFFDADADA),
+    secondary = Color(0xFF12AC97),
+    secondaryVariant = Color(0xFF007C69),
+    onSecondary = Color(0xFF121212),
+    background = Color(0xFFF5F5F5),
+    onBackground = Color(0xFF121212),
+    backgroundVariant = Color(0xFF006C5D),
+    onBackgroundVariant = Color(0xFFDADADA),
+    surface = Color(0xFFFFFFFF),
+    onSurface = Color(0xFF121212),
+    error = Color(0xFFA82D2D),
+    onError = Color(0xFF121212),
+    isLight = true
+)
 ```
-and you can retrieve those values in your application as simple as
+then declare/choose your typography
 ```kotlin
-val kfg = konfig()
-val link: String by kfg // onDebug:(debug.com), onStaging(staging.com), onRelease(release.com)
+val myTypography = Typography(
+    h1 = TextStyle(fontSize = 2.rem),
+    h2 = TextStyle(fontSize = 1.5.rem),
+    h3 = TextStyle(fontSize = 1.17.rem),
+    h4 = TextStyle(fontSize = 1.0.rem),
+    h5 = TextStyle(fontSize = 0.83.rem),
+    h6 = TextStyle(fontSize = 0.67.rem),
+    subtitle1 = TextStyle(fontSize = 1.25.rem),
+    subtitle2 = TextStyle(fontSize = 1.15.rem),
+    body1 = TextStyle(fontSize = 1.0.rem),
+    body2 = TextStyle(fontSize = 1.0.rem),
+    button = TextStyle(fontSize = 1.0.rem),
+    caption = TextStyle(fontSize = 0.9.rem),
+    overline = TextStyle(fontSize = 0.9.rem)
+)
 ```
 
+Then declare your theme
+```kotlin
+val AquaGreenTheme = Theme(
+    name = "aQua Green",
+    color = AquaGreenPallet,
+    text = Typography()
+)
+```
 ## Setup:Gradle
-Konfig comes with a gradle plugin as a well as a runtime library. Just do the following
-
-### Kotlin Multiplatform
 ```kotlin
-plugins {
-    // . . . .
-    id("tz.co.asoft.konfig") version "0.0.2"
-}
-
-// . . .
-
 dependencies {
-    implementation("tz.co.asoft:konfig:+") // please use the latest version possible
+    implementation("tz.co.asoft:theme-core:+") // please use the latest version possible
 }
 ```
 
-## Konfig Plugin
-Setting up the konfig plugin makes it easy to help configure your buildTypes.
+## Default Themes
+The engine comes with 2 default `ColorPalette` and a default `Typography` per platform/framework/library
+### AquaGreenTheme
+The values are set as shown on the code above
 
-### DRY - Don't Repeat Yourself
-Consider the following konfiguration
+### DarkGrayTheme
+Whose color palette is as bellow
 ```kotlin
-konfig{
-    debug(
-        "app_name" to "My Killer App",
-        "api_link" to "https://debug.com"
-    )
-    . . .
-    release(
-        "app_name" to "My Killer App",
-        "api_link" to "https://release.com"
-    )
-}
-```
-This repetition can be solved by the common konfiguration. Like so
+val DarkGrayPallet = ColorPalette(
+    primary = Color(0xFF1F3D4C),
+    primaryVariant = Color(0xFF455A64),
+    onPrimary = Color(0xFFDADADA),
+    secondary = Color(0xFF12AC97),
+    secondaryVariant = Color(0xFF007C69),
+    onSecondary = Color(0xFF121212),
+    background = Color(0xFF080808),
+    onBackground = Color(0xFFFFFFFF),
+    backgroundVariant = Color(0xFF121212),
+    onBackgroundVariant = Color(0xFFFFFFFF),
+    surface = Color(0xFF17181A),
+    onSurface = Color(0xFFFFFFFF),
+    error = Color(0xFFA82D2D),
+    onError = Color(0xFF121212),
+    isLight = false
+)
+``` 
+
+### ColorPalette Extensions
+While you can craft your own themes, you'll often need to just extend a theme. You can do it simply just like
 ```kotlin
-konfig{
-    common(
-        "app_name" to "My Killer App"
-    )
-    debug(
-        "api_link" to "https://debug.com"
-    )
-    . . .
-    release(
-        "api_link" to "https://release.com"
-    )
-}
+val PaleGreenPalette = AquaGreenPalette.copy(
+    primary = Color(0xFF98FB98)
+)
 ```
-Just remember, common is a reserved builder. Don't think it creates a buildType with the name "common"
 
-### Nested Structures
-konfig supports nested structures, and since it uses [kotlinx-serialization-mapper](https://github.com/aSoft-Ltd/kotlinx-serialization-mapper)
-extracting your nested structure is easy
+### Using with kotlin-react
+A react specific artifact is available for targeting `kotlin-react` specifically
+#### Sample
 ```kotlin
-konfig {
-    debug(
-        "license" to "MIT",
-        "devs" to listOf(
-            mapOf(
-                "name" to "John Doe",
-                "email" to "john@doe.com"
-            ),
-            mapOf(
-                "name" to "Jane Doe",
-                "email" to "jane@doe.com"
-            )
-        )
-    )
-}
+    fun RBuilder.TestComp(myTheme: ReactTheme) = ThemeProvider(myTheme) { 
+        div {
+            +"Test sample"
+        }
+        ThemeConsumer{theme->
+            h1 {
+               attrs["background"] = theme.color.primary() 
+            }
+        }
+    }
 ```
-You can even go crazy and do something like
+#### Setup: Gradle
 ```kotlin
-data class Dev(val name: String, val email: String)
-konfig {
-    debug(
-        "license" to "MIT",
-        "devs" to listOf(
-            Dev(name = "John Doe", email = "john@doe.com") // or just Dev("John Doe","john@doe.com")
-            Dev(name = "Jane Doe", email = "jave@doe.com"),
-        )
-    )
+dependencies {
+    implementation("tz.co.asoft:theme-react:+") // please use the latest version possible
 }
 ```
 
-And you can retrieve your data as easy as
-```kotlin
-val kfg = konfig()
-val license: String by kfg
-val devs: List<Map<String,String>> by kfg
-
-val name by devs[0]
-val email by devs[1]
-
-println(name) // John Doe
-println(email) // jane@doe.com
-```
-
-### Naming your konfigs
-You can name your konfigs if you wan't to, by default the names of the konfigs are as their buildType
-i.e debug -> debug, staging->stagin, release->release
-If you need to have a debug buildType named free, you can go just do as follows
-```kotlin
-konfig {
-    debug("free_debug",
-        "license" to "MIT"
-    )
-
-    debug("paid_debug"
-        "licence" to "aSoft Ltd"
-    )
-}
-```
-
-## Application Plugin
-Very often, you need to automate how you collect your configurations. This should be as easy as setting up your configurations and run
-the build type you want. The `application` plugin gives you exactly that. But since every platform has it's own way of doing things we will tackle each of it seprately
-
-### Android Application
-#### Setup
-To setup the android application, you must declare the gradle plugins as follows (the order is important)
-```kotlin
-plugins {
-    id("com.android.application")
-    kotlin("android")
-    id("tz.co.asoft.application")
-}
-// . . .
-konfig{
-    debug()
-    staging()
-    release()
-}
-```
-#### Gradle Tasks
-For each of the konfigurations above, the following gradle tasks are set
-1. generate[Konfig]KonfigFile -> generates a json file with the set configuration
-2. installRun[Konfig] -> a gradle task that installs and runs the specific version on a device or emulator
-
-### JVM Application
-This gradle plugin, applies the native java application plugin and ads a few tasks more
-
-#### Setup
-```kotlin
-plugins {
-    kotlin("jvm")
-    id("tz.co.asoft.application")
-}
-
-application {
-    mainClassName = "path.to.class.NameKt" // required by the `application` plugin
-}
-// . . .
-konfig{
-    debug()
-    staging()
-    release()
-}
-```
-#### Gradle Tasks
-1. generate[Konfig]KonfigFile -> generate a json file for the konfigurations set
-2. fatJar[Konfig] -> generates a fat jar in the `build/libs` of the specific konfiguration
-3. installDist[Konfig] -> generates a distributable in `build/binaries` which is package together with it dependencies
-4. run[Konfig] -> runs the application depending on the buildType
-
-### Browser Application
-This shouldn't be confused with Javascript Applications. As we currently do not support nodejs applications
-#### Setup
-```kotlin
-plugins {
-    kotlin("js")
-    id("tz.co.asoft.application")
-}
-
-// . . .
-konfig{
-    debug()
-    staging()
-    release()
-}
-```
-
-#### Gradle Tasks
-1. generate[Konfig]KonfigFile -> generates a json konfig file for that konfiguration
-2. webpack[Konfig] -> creates a minified webpack bundle that can be deployed to any server
-3. run[Konfig] -> opens the browser and runs the konfiguration. You should note that all debug types are not minified for obvious reasons, the rest are minified
-
-### Multiplatform Application
-This plugin helps you write multiplatform application in one code base
-#### Setup
-```kotlin
-plugins {
-    id("com.android.application") version "4.1.0"
-    kotlin("multiplatform") version "1.4.10"
-    id("tz.co.asoft.application")
-}
-
-// . . .
-konfig{
-    debug()
-    staging()
-    release()
-}
-```
-#### Gradle Tasks
-##### If you have an android target with the name "android", you will get the following tasks
-1. generateAndroid[Konfig]KonfigFile -> generate the json config file for the android target
-2. installRunAndroid[Konfig] -> install and runs the application on a phone or emulator
-
-N.B: If your target has a different name, feel free to swap the name with the word androd on the tasks
-
-##### If you have a jvm target with the name "jvm", you will get the following tasks
-1. generateJVM[Konfig]KonfigFile -> generate the json config file for the android target
-2. fatJarJvm[Konfig] -> generates a fat jar of the java app in the `build/libs` of the specific konfiguration
-3. runJvm[Konfig] -> runs the jvm application
-
-N.B: To run the JVM application from `kotlin("multiplatform")` gradle plugin, you must declare an attribute "Main-Class" in your Konfig
-
-##### If you have a browser target with the name "js", you will get the following tasks
-1. generateJs[Konfig]KonfigFile -> generates a json konfig file for that konfiguration
-2. webpackJs[Konfig] -> creates a minified webpack bundle that can be deployed to any server
-3. runJs[Konfig] -> opens the browser and runs the js app with the provided konfiguration. You should note that all debug types are not minified for obvious reasons, the rest are minified
+### Comming Soon
+#### Theme Compose
+We are working on porting the theme lib to jetpack compose as well, that way you can have one theme on web, android and desktop
 
 [badge-maven]: https://img.shields.io/maven-central/v/tz.co.asoft/test/1.0.1?style=flat
 [badge-mpp]: https://img.shields.io/badge/kotlin-multiplatform-blue?style=flat

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+    kotlin("multiplatform") version "1.4.10" apply false
+    id("tz.co.asoft.library") version "1.0.0" apply false
+    id("io.codearte.nexus-staging") version "0.22.0" apply false
+}

--- a/buildSrc/gradle/wrapper/gradle-wrapper.properties
+++ b/buildSrc/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,3 +18,4 @@ pluginManagement {
 rootProject.name = "theme"
 
 include(":theme-core")
+include(":theme-react")

--- a/theme-core/build.gradle.kts
+++ b/theme-core/build.gradle.kts
@@ -1,9 +1,10 @@
 plugins {
-    id("com.android.library") version "4.1.0"
-    kotlin("multiplatform") version "1.4.10"
-    id("tz.co.asoft.library") version "0.0.7"
+    id("com.android.library")
+    kotlin("multiplatform")
+    id("tz.co.asoft.library")
+    id("io.codearte.nexus-staging")
+    signing
 }
-
 
 kotlin {
     universalLib()
@@ -25,3 +26,8 @@ kotlin {
         }
     }
 }
+
+aSoftLibrary(
+    version = vers.asoft.theme,
+    description = "A platform/framework agnostic theme engine"
+)

--- a/theme-core/src/commonMain/kotlin/tz/co/asoft/Theme.kt
+++ b/theme-core/src/commonMain/kotlin/tz/co/asoft/Theme.kt
@@ -3,7 +3,7 @@ package tz.co.asoft
 /**
  * @property T is the typography of the respective platform
  */
-data class Theme<T>(
+data class Theme<T : Any>(
     val name: String,
     val color: ColorPalette,
     val text: T

--- a/theme-core/src/jsMain/kotlin/tz/co/asoft/Theme.core.ktx.kt
+++ b/theme-core/src/jsMain/kotlin/tz/co/asoft/Theme.core.ktx.kt
@@ -6,20 +6,20 @@ import kotlinx.css.Color as CSSColor
 
 inline val Color.color get() = rgba(red.to255Int(), green.to255Int(), blue.to255Int(), alpha.toDouble())
 
-inline val Theme<*>.primaryColor get() = color.primary.color
-inline val Theme<*>.primaryVariantColor get() = color.primaryVariant.color
-inline val Theme<*>.onPrimaryColor get() = color.onPrimary.color
-inline val Theme<*>.secondaryColor get() = color.secondary.color
-inline val Theme<*>.secondaryVariantColor get() = color.secondaryVariant.color
-inline val Theme<*>.onSecondaryColor get() = color.onSecondary.color
-inline val Theme<*>.backgroundColor get() = color.background.color
-inline val Theme<*>.onBackgroundColor get() = color.onBackground.color
-inline val Theme<*>.backgroundVariantColor get() = color.backgroundVariant.color
-inline val Theme<*>.onBackgroundVariantColor get() = color.onBackgroundVariant
-inline val Theme<*>.surfaceColor get() = color.surface.color
-inline val Theme<*>.onSurfaceColor get() = color.onSurface.color
-inline val Theme<*>.errorColor get() = color.error.color
-inline val Theme<*>.onErrorColor get() = color.onError.color
+inline val Theme<Typography>.primaryColor get() = color.primary.color
+inline val Theme<Typography>.primaryVariantColor get() = color.primaryVariant.color
+inline val Theme<Typography>.onPrimaryColor get() = color.onPrimary.color
+inline val Theme<Typography>.secondaryColor get() = color.secondary.color
+inline val Theme<Typography>.secondaryVariantColor get() = color.secondaryVariant.color
+inline val Theme<Typography>.onSecondaryColor get() = color.onSecondary.color
+inline val Theme<Typography>.backgroundColor get() = color.background.color
+inline val Theme<Typography>.onBackgroundColor get() = color.onBackground.color
+inline val Theme<Typography>.backgroundVariantColor get() = color.backgroundVariant.color
+inline val Theme<Typography>.onBackgroundVariantColor get() = color.onBackgroundVariant
+inline val Theme<Typography>.surfaceColor get() = color.surface.color
+inline val Theme<Typography>.onSurfaceColor get() = color.onSurface.color
+inline val Theme<Typography>.errorColor get() = color.error.color
+inline val Theme<Typography>.onErrorColor get() = color.onError.color
 
 val TextStyle.clazz: RuleSet
     get() = {
@@ -37,7 +37,7 @@ val TextStyle.clazz: RuleSet
         this@clazz.lineHeight?.let { lineHeight = it }
     }
 
-val Theme<*>.dropdown_clazz: RuleSet
+val Theme<Typography>.dropdown_clazz: RuleSet
     get() = {
         outline = Outline.none
         color = CSSColor.inherit

--- a/theme-core/src/jsMain/kotlin/tz/co/asoft/Theme.core.ktx.kt
+++ b/theme-core/src/jsMain/kotlin/tz/co/asoft/Theme.core.ktx.kt
@@ -3,25 +3,24 @@ package tz.co.asoft
 import kotlinx.css.*
 import kotlinx.css.Color as CSSColor
 
+operator fun Color.invoke() = rgba(red.to255Int(), green.to255Int(), blue.to255Int(), alpha.toDouble())
 
-inline val Color.color get() = rgba(red.to255Int(), green.to255Int(), blue.to255Int(), alpha.toDouble())
+inline val Theme<Typography>.primaryColor get() = color.primary()
+inline val Theme<Typography>.primaryVariantColor get() = color.primaryVariant()
+inline val Theme<Typography>.onPrimaryColor get() = color.onPrimary()
+inline val Theme<Typography>.secondaryColor get() = color.secondary()
+inline val Theme<Typography>.secondaryVariantColor get() = color.secondaryVariant()
+inline val Theme<Typography>.onSecondaryColor get() = color.onSecondary()
+inline val Theme<Typography>.backgroundColor get() = color.background()
+inline val Theme<Typography>.onBackgroundColor get() = color.onBackground()
+inline val Theme<Typography>.backgroundVariantColor get() = color.backgroundVariant()
+inline val Theme<Typography>.onBackgroundVariantColor get() = color.onBackgroundVariant()
+inline val Theme<Typography>.surfaceColor get() = color.surface()
+inline val Theme<Typography>.onSurfaceColor get() = color.onSurface()
+inline val Theme<Typography>.errorColor get() = color.error()
+inline val Theme<Typography>.onErrorColor get() = color.onError()
 
-inline val Theme<Typography>.primaryColor get() = color.primary.color
-inline val Theme<Typography>.primaryVariantColor get() = color.primaryVariant.color
-inline val Theme<Typography>.onPrimaryColor get() = color.onPrimary.color
-inline val Theme<Typography>.secondaryColor get() = color.secondary.color
-inline val Theme<Typography>.secondaryVariantColor get() = color.secondaryVariant.color
-inline val Theme<Typography>.onSecondaryColor get() = color.onSecondary.color
-inline val Theme<Typography>.backgroundColor get() = color.background.color
-inline val Theme<Typography>.onBackgroundColor get() = color.onBackground.color
-inline val Theme<Typography>.backgroundVariantColor get() = color.backgroundVariant.color
-inline val Theme<Typography>.onBackgroundVariantColor get() = color.onBackgroundVariant
-inline val Theme<Typography>.surfaceColor get() = color.surface.color
-inline val Theme<Typography>.onSurfaceColor get() = color.onSurface.color
-inline val Theme<Typography>.errorColor get() = color.error.color
-inline val Theme<Typography>.onErrorColor get() = color.onError.color
-
-val TextStyle.clazz: RuleSet
+inline val TextStyle.clazz: RuleSet
     get() = {
         this@clazz.color?.let { color = it }
         this@clazz.fontSize?.let { fontSize = it }
@@ -29,15 +28,12 @@ val TextStyle.clazz: RuleSet
         this@clazz.fontStyle?.let { fontStyle = it }
         this@clazz.fontFamily?.let { fontFamily = it }
         this@clazz.letterSpacing?.let { letterSpacing = it }
-//        this@clazz.baselineShift
         this@clazz.background?.let { backgroundColor = it }
-//        this@clazz.textDecoration
         this@clazz.textAlign?.let { textAlign = it }
-//        this@clazz.textDirection?.let {  }
         this@clazz.lineHeight?.let { lineHeight = it }
     }
 
-val Theme<Typography>.dropdown_clazz: RuleSet
+inline val Theme<Typography>.dropdown_clazz: RuleSet
     get() = {
         outline = Outline.none
         color = CSSColor.inherit

--- a/theme-react/build.gradle.kts
+++ b/theme-react/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    kotlin("js")
+    id("tz.co.asoft.library")
+    id("io.codearte.nexus-staging")
+    signing
+}
+
+kotlin {
+    js(IR) {
+        browser()
+    }
+}
+
+dependencies {
+    api(project(":theme-core"))
+    api("org.jetbrains:kotlin-react:${vers.wrappers.react}")
+}
+
+aSoftLibrary(
+    version = vers.asoft.theme,
+    description = "A theme engine for kotlin/react"
+)

--- a/theme-react/src/main/kotlin/tz/co/asoft/ReactTheme.kt
+++ b/theme-react/src/main/kotlin/tz/co/asoft/ReactTheme.kt
@@ -1,0 +1,3 @@
+package tz.co.asoft
+
+typealias ReactTheme = Theme<Typography>

--- a/theme-react/src/main/kotlin/tz/co/asoft/ThemeContext.kt
+++ b/theme-react/src/main/kotlin/tz/co/asoft/ThemeContext.kt
@@ -1,0 +1,11 @@
+package tz.co.asoft
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import react.RBuilder
+import react.createContext
+
+val currentTheme by lazy { MutableStateFlow(AquaGreenTheme) }
+
+val ThemeContext by lazy { createContext(currentTheme.value) }
+
+fun RBuilder.ThemeConsumer(handler: RBuilder.(Theme<Typography>) -> Unit) = ThemeContext.Consumer(handler)

--- a/theme-react/src/main/kotlin/tz/co/asoft/ThemeContext.kt
+++ b/theme-react/src/main/kotlin/tz/co/asoft/ThemeContext.kt
@@ -8,4 +8,4 @@ val currentTheme by lazy { MutableStateFlow(AquaGreenTheme) }
 
 val ThemeContext by lazy { createContext(currentTheme.value) }
 
-fun RBuilder.ThemeConsumer(handler: RBuilder.(Theme<Typography>) -> Unit) = ThemeContext.Consumer(handler)
+fun RBuilder.ThemeConsumer(handler: RBuilder.(ReactTheme) -> Unit) = ThemeContext.Consumer(handler)

--- a/theme-react/src/main/kotlin/tz/co/asoft/ThemeProvider.kt
+++ b/theme-react/src/main/kotlin/tz/co/asoft/ThemeProvider.kt
@@ -11,11 +11,11 @@ import react.*
 
 private class ThemeProvider(p: Props) : RComponent<ThemeProvider.Props, ThemeProvider.State>(p), CoroutineScope by CoroutineScope(SupervisorJob()) {
     class Props(
-        val observerFrom: StateFlow<Theme<Typography>>,
-        val handler: RHandler<RProviderProps<Theme<Typography>>>
+        val observerFrom: StateFlow<ReactTheme>,
+        val handler: RHandler<RProviderProps<ReactTheme>>
     ) : RProps
 
-    class State(var theme: Theme<Typography>) : RState
+    class State(var theme: ReactTheme) : RState
 
     init {
         state = State(p.observerFrom.value)
@@ -38,19 +38,19 @@ private class ThemeProvider(p: Props) : RComponent<ThemeProvider.Props, ThemePro
     }
 }
 
-private fun Theme<Typography>.imposeToDocument() = document.body?.style?.also {
+private fun ReactTheme.imposeToDocument() = document.body?.style?.also {
     it.backgroundColor = backgroundColor.value
     it.color = onBackgroundColor.value
 }
 
 fun RBuilder.ThemeProvider(
-    observerFrom: StateFlow<Theme<Typography>> = currentTheme,
-    handler: RHandler<RProviderProps<Theme<Typography>>>
+    observerFrom: StateFlow<ReactTheme> = currentTheme,
+    handler: RHandler<RProviderProps<ReactTheme>>
 ) = child(ThemeProvider::class.js, ThemeProvider.Props(observerFrom, handler)) {}
 
 fun RBuilder.ThemeProvider(
-    theme: Theme<Typography>,
-    handler: RHandler<RProviderProps<Theme<Typography>>>
+    theme: ReactTheme,
+    handler: RHandler<RProviderProps<ReactTheme>>
 ) = ThemeContext.Provider(theme, handler).apply {
     theme.imposeToDocument()
 }

--- a/theme-react/src/main/kotlin/tz/co/asoft/ThemeProvider.kt
+++ b/theme-react/src/main/kotlin/tz/co/asoft/ThemeProvider.kt
@@ -1,0 +1,56 @@
+package tz.co.asoft
+
+import kotlinx.browser.document
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import react.*
+
+private class ThemeProvider(p: Props) : RComponent<ThemeProvider.Props, ThemeProvider.State>(p), CoroutineScope by CoroutineScope(SupervisorJob()) {
+    class Props(
+        val observerFrom: StateFlow<Theme<Typography>>,
+        val handler: RHandler<RProviderProps<Theme<Typography>>>
+    ) : RProps
+
+    class State(var theme: Theme<Typography>) : RState
+
+    init {
+        state = State(p.observerFrom.value)
+    }
+
+    override fun componentDidMount() {
+        launch {
+            props.observerFrom.collect {
+                setState { theme = it }
+            }
+        }
+    }
+
+    override fun componentWillUnmount() {
+        cancel()
+    }
+
+    override fun RBuilder.render(): dynamic = ThemeContext.Provider(state.theme, props.handler).apply {
+        state.theme.imposeToDocument()
+    }
+}
+
+private fun Theme<Typography>.imposeToDocument() = document.body?.style?.also {
+    it.backgroundColor = backgroundColor.value
+    it.color = onBackgroundColor.value
+}
+
+fun RBuilder.ThemeProvider(
+    observerFrom: StateFlow<Theme<Typography>> = currentTheme,
+    handler: RHandler<RProviderProps<Theme<Typography>>>
+) = child(ThemeProvider::class.js, ThemeProvider.Props(observerFrom, handler)) {}
+
+fun RBuilder.ThemeProvider(
+    theme: Theme<Typography>,
+    handler: RHandler<RProviderProps<Theme<Typography>>>
+) = ThemeContext.Provider(theme, handler).apply {
+    theme.imposeToDocument()
+}


### PR DESCRIPTION
# 0.0.1
## Availability
- Published to maven central

## Build Src
- Updated to gradle version 6.7.1

## New Features
### theme-core-metadata
- Added `ColorPallet` class
- Added `Theme<T>` class

### theme-core-js
- Added `TextStyle` class for any web framework
- Added `Typograpgy` class for any web framework
- Added `operator fun Color.invoke()` to make it easy convert to CSS colors

### theme-react
- Added `TextStyle`
- Added `ReactTheme` type alias of `Theme<Typography>`
- Added `ThemeContext`
- Added `fun RBuilder.ThemeProvider(...)`
- Added `fun RBuilder.ThemeConsumer(...)`

### library
- Added the `konfig()` method, on all supported platforms

## Documentation
- Update readme

## Samples
- Added samples